### PR TITLE
Pinned all dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,20 +22,20 @@
     "mailer"
   ],
   "dependencies": {
-    "bluebird": "^2.9.30",
-    "lodash": "^3.10.0",
-    "nodemailer": "^1.3.4",
-    "nodemailer-direct-transport": "^1.0.2",
-    "nodemailer-sendgrid-transport": "^0.2.0",
-    "nodemailer-sendmail-transport": "^1.0.0",
-    "nodemailer-ses-transport": "^1.3.0",
-    "nodemailer-smtp-transport": "^1.0.3",
-    "nodemailer-stub-transport": "^1.0.0"
+    "bluebird": "2.10.1",
+    "lodash": "3.10.1",
+    "nodemailer": "1.5.0",
+    "nodemailer-direct-transport": "1.0.2",
+    "nodemailer-sendgrid-transport": "0.2.0",
+    "nodemailer-sendmail-transport": "1.0.0",
+    "nodemailer-ses-transport": "1.3.0",
+    "nodemailer-smtp-transport": "1.0.3",
+    "nodemailer-stub-transport": "1.0.0"
   },
   "devDependencies": {
-    "chai": "^3.0.0",
-    "istanbul": "^0.3.14",
-    "mocha": "^2.2.5",
-    "sinon": "^1.15.3"
+    "chai": "3.3.0",
+    "istanbul": "0.3.21",
+    "mocha": "2.3.3",
+    "sinon": "1.17.1"
   }
 }


### PR DESCRIPTION
:wave: Hello!

We’re all trying to keep our software up to date, yet stable at the same time.

This is the first in a series of automatic PRs to help you achieve this goal. It pins all of the dependencies in your `package.json`, so you have complete control over the exact state of your software.

From now on you’ll receive PRs whenever one of your dependencies updates – in real time. This way you get all the benefits of up-to-date dependencies, while having them pinned at the same time. This means:
- No more surprises because some of your dependencies didn’t follow [SemVer](http://semver.org/). Your software is always in a state you know about, regardless of _when_ someone does `$ npm install`.
- If you have continuous integration set up for this repo, it’ll run automatically. Ideally, it will pass and you'll stay up to date with the press of a button. If the updated dependency _does_ break your software, it won’t affect your users, because their dependencies are still pinned to the working state.
- You can immediately identify which dependency updates break your software, because each one is tested in isolation. You’ll also have a branch ready to work on, so adapting to new APIs is way faster.

Merge this PR and you’ll have up-to-date software without the headaches :sparkles:

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
