### PR TITLE
Updated nodemailer to version 1.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "dependencies": {
     "lodash": "3.10.1",
-    "nodemailer": "1.6.0",
+    "nodemailer": "1.7.0",
     "nodemailer-direct-transport": "1.0.2",
     "nodemailer-sendgrid-transport": "0.2.0",
     "nodemailer-sendmail-transport": "1.0.0",


### PR DESCRIPTION
:rocket:

nodemailer just published version 1.7.0, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---

The new version differs by 1 commits (ahead by 1, behind by 0).
- [254a402](https://github.com/andris9/Nodemailer/commit/254a4024cdbbb0fb0e6903bd065cb7bfc56805ab): Bumped version to v1.7.0. Replaced hyperquest with needle that should fix most issues with redirects and gzipped content

See the [full diff](https://github.com/andris9/Nodemailer/compare/529a8c92c2cda2d810410fc6406e07576ddde290...254a4024cdbbb0fb0e6903bd065cb7bfc56805ab).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
